### PR TITLE
[feat] 매치 종료 기능 보완 및  end 이벤트리스너 구현

### DIFF
--- a/src/class/room/room.class.js
+++ b/src/class/room/room.class.js
@@ -1,4 +1,4 @@
-import startMatchHandler from '../../handlers/match/start.match.handler.js';
+import startMatch from '../../utils/match/start.match.js';
 import Player from '../in-game/player.class.js';
 import EloRank from 'elo-rank';
 
@@ -30,13 +30,23 @@ class Room {
     this.players.set(userA.id, new Player(userA, userB.id));
     this.players.set(userB.id, new Player(userB, userA.id));
     // [3] 매치 시작 핸들러 실행
-    startMatchHandler(this);
+    startMatch(this);
     /* 밑은 기존 코드 */
     // for (let user of users) {
     //   user.enterRoom(this.id);
     //   this.players.set(user.id, new Player(user.id, user.socket, this.id, user));
     // }
     // finishMatchHandler(this);
+  }
+
+  /* 룸 비우기 */
+  clearRoom() {
+    // [1] 소속 유저들 roomId 초기화
+    for (const player of this.players.values()) {
+      player.user.roomId = null;
+    }
+    // [2] Map 인스턴스 초기화
+    this.players.clear();
   }
 
   getUser(id) {
@@ -74,7 +84,6 @@ class Room {
     // [3] 예상 승리 확률과 실제 승패를 바탕으로 각각의 mmr 최신화
     winner.mmr = elo.updateRating(winProbability.winner, 1, winner.mmr); // 1은 실제로 승리했다는 의미
     loser.mmr = elo.updateRating(winProbability.loser, 0, loser.mmr); // 0은 실제로 패배했다는 의미, 참고로 0.5는 비겼다는 의미
-    console.log(`!!! 승자 : ${winner.mmr} / 패자 : ${loser.mmr} !!!`);
   }
 
   broadcastOthers(packetType, payload, id) {

--- a/src/class/room/room.session.class.js
+++ b/src/class/room/room.session.class.js
@@ -18,10 +18,15 @@ class RoomSession {
     return this.rooms;
   }
 
+  /* 룸 세션에서 매치 종료된 룸 제거 */
   deleteRoom(roomId) {
+    // [1] 종료시킬 룸 검색
+    const room = this.rooms.get(roomId);
+    // [2] 룸 비우고, 소속 유저들 roomId도 초기화
+    room.clearRoom();
+    // [3] 처리 끝난 룸 제거
     this.rooms.delete(roomId);
   }
-  // 메서드 추가
 }
 
 export default RoomSession;

--- a/src/class/user/user.class.js
+++ b/src/class/user/user.class.js
@@ -11,22 +11,22 @@ class User {
     this.socket = socket;
     this.state = userState.waiting; // "waiting", "matchMaking", "playing"
 
-    this.highScore = null;
     this.matchRecord = {
       win: null,
       lose: null,
     };
     this.mmr = null;
+    this.highScore = null;
     this.sequence = 1;
   }
 
-  login(key, userId, highScore, winCount, loseCount, mmr) {
+  login(key, userId, winCount, loseCount, mmr, highScore) {
     this.key = key;
     this.id = userId;
-    this.highScore = highScore;
     this.matchRecord.win = winCount;
     this.matchRecord.lose = loseCount;
     this.mmr = mmr;
+    this.highScore = highScore;
   }
 
   enterRoom(roomId) {
@@ -43,7 +43,7 @@ class User {
   }
 
   /* 경기 결과 최신화시키기 */
-  updateMatchRecord(isWin) {
+  updateMatchRecord(isWin, scoreResult) {
     // [1] 경기 종료됐으니 유저 상태 "대기"로 변경
     this.state = userState.waiting;
     // [2] 이겼으면 승수 + 1, 졌으면 패수 + 1
@@ -52,10 +52,9 @@ class User {
     } else {
       this.matchRecord.lose += 1;
     }
-    console.log(`!!! 승수 : ${this.matchRecord.win} / 패수 : ${this.matchRecord.lose} !!!`);
+    // [3] 획득 점수가 최고 기록 보다 높다면 최신화
+    if (scoreResult > this.highScore) this.highScore = scoreResult;
   }
-
-  calculateMmr() {}
 
   getSequence() {
     return this.sequence++;

--- a/src/class/user/user.session.class.js
+++ b/src/class/user/user.session.class.js
@@ -3,10 +3,10 @@ import User from './user.class.js';
 class UserSession {
   users = new Map();
 
-  setUser(socket) {
+  addUser(socket) {
     const newUser = new User(socket);
     this.users.set(socket, newUser);
-    console.log("유저생성")
+    console.log('유저생성');
     return newUser;
   }
 
@@ -14,12 +14,12 @@ class UserSession {
     return this.users.get(socket);
   }
 
-  removeUser(socket) {
-    this.users.delete(socket);
-  }
-
   getAllUsers() {
     return this.users; // 객체나 배열로 바꿔서 줘야하나? 쓸 일이 있을까 근데?
+  }
+
+  deleteUser(socket) {
+    this.users.delete(socket);
   }
 
   clearUserSession() {

--- a/src/database/user_db/functions.js
+++ b/src/database/user_db/functions.js
@@ -1,11 +1,11 @@
 import pools from '../pools.js';
-import USER_SQL_QUERIES from './queries.js';
+import USERS_QUERIES from './queries.js';
 
 /* 회원가입 시 실행하는 쿼리 함수 */
 const insertUserData = async (id, password, email) => {
   try {
     // [1] 가입 정보 저장하기
-    await pools.USER_DB.execute(USER_SQL_QUERIES.INSERT_USER, [id, password, email]);
+    await pools.USER_DB.execute(USERS_QUERIES.INSERT_USER, [id, password, email]);
   } catch (error) {
     // [2] 실패 시 에러 객체 상위 함수로 전달
     throw error;
@@ -16,7 +16,7 @@ const insertUserData = async (id, password, email) => {
 const selectUserData = async (id) => {
   try {
     // [1] 유저 정보와 랭크 정보 가져오기
-    const [user] = await pools.USER_DB.execute(USER_SQL_QUERIES.SELECT_USER, [id]);
+    const [user] = await pools.USER_DB.execute(USERS_QUERIES.SELECT_USER, [id]);
     return user[0];
   } catch (error) {
     // [2] 실패 시 에러 객체 상위 함수로 전달
@@ -24,4 +24,21 @@ const selectUserData = async (id) => {
   }
 };
 
-export { insertUserData, selectUserData };
+/* 게임 종료 시 실행하는 쿼리 함수 */
+const updateUserData = async (winCount, loseCount, mmr, highScore, userKey) => {
+  try {
+    // [1] 게임 진행 정보 최신화하기
+    await pools.USER_DB.execute(USERS_QUERIES.UPDATE_USER, [
+      winCount,
+      loseCount,
+      mmr,
+      highScore,
+      userKey,
+    ]);
+  } catch (error) {
+    // [2] 실패 시 에러 객체 상위 함수로 전달
+    throw error;
+  }
+};
+
+export { insertUserData, selectUserData, updateUserData };

--- a/src/database/user_db/queries.js
+++ b/src/database/user_db/queries.js
@@ -1,6 +1,7 @@
-const USER_SQL_QUERIES = {
+const USERS_QUERIES = {
   INSERT_USER: `INSERT INTO users (id, password, email) VALUES (?, ?, ?)`,
   SELECT_USER: `SELECT user_key, id, password, win_count, lose_count, mmr, high_score FROM users WHERE id = ?`,
+  UPDATE_USER: `UPDATE users SET win_count=?, lose_count=?, mmr =?, high_score=? WHERE user_key=?`,
 };
 
-export default USER_SQL_QUERIES;
+export default USERS_QUERIES;

--- a/src/event-listener/connect.js
+++ b/src/event-listener/connect.js
@@ -15,7 +15,7 @@ const onConnection = (socket) => {
   socket.on(`end`, onEnd(socket));
   socket.on(`error`, onError(socket));
   // [4] 깡통 유저 생성
-  userSession.setUser(socket);
+  userSession.addUser(socket);
 };
 
 export default onConnection;

--- a/src/event-listener/end.js
+++ b/src/event-listener/end.js
@@ -1,5 +1,35 @@
-const onEnd = (socket) => () => {
-  console.log('end 이벤트 발동 확인');
+import { roomSession, userSession } from '../session/session.js';
+import { updateUserData } from '../database/user_db/functions.js';
+import finishMatch from '../utils/match/finish.match.js';
+
+const onEnd = (socket) => async () => {
+  // [1] 접속 종료한 유저 검색
+  const user = userSession.getUser(socket);
+  console.log(`클라 접속 종료!! : ${user.id}`);
+  // [2] 만약 매치가 진행 중일 시 처리
+  if (user.roomId) {
+    // [2-1] 진행 중인 룸 검색
+    const room = roomSession.getRoom(user.roomId);
+    // [2-2] 승패 판정 후 gameOverNotification 보내고 매치 결과 적용 후 룸 제거
+    finishMatch(room, user);
+  }
+  // [3] 전적과 mmr, 하이스코어 데이터베이스에 저장
+  try {
+    await updateUserData(
+      user.matchRecord.win,
+      user.matchRecord.lose,
+      user.mmr,
+      user.highScore,
+      user.key,
+    );
+  } catch (error) {
+    console.error(`로그아웃 처리 중 문제 발생!! `, error);
+  }
+  // [4] 유저 세션에서 해당 유저 제거
+  userSession.deleteUser(socket);
+  // [5] 소켓 제거
+  socket.end();
+  socket.destroy();
 };
 
 export default onEnd;

--- a/src/handlers/user/login.handler.js
+++ b/src/handlers/user/login.handler.js
@@ -59,10 +59,10 @@ const verifyLoginInfo = async (user, id, password) => {
   user.login(
     userData.user_key,
     userData.id,
-    userData.high_score,
     userData.win_count,
     userData.lose_count,
     userData.mmr,
+    userData.high_score,
   );
   // [7] 성공 응답 페이로드 반환
   return { success: true, message: messageType.success, token, failCode: GlobalFailCode.NONE };

--- a/src/utils/match/finish.match.js
+++ b/src/utils/match/finish.match.js
@@ -1,0 +1,25 @@
+import config from '../../config/configs.js';
+import { roomSession } from '../../session/session.js';
+
+/* 매치 종료하고 결과 적용하기 */
+const finishMatch = (room, user) => {
+  // [1] 매치 결과 기록할 객체 생성
+  const matchResult = { winner: '', loser: '' };
+  // [2] 플레이어 별로 결과 적용
+  room.players.forEach((player, playerId) => {
+    // [2-1] 승패 판정 (패배한 user가 호출하게 됨)
+    const isWin = playerId === user.id ? false : true;
+    if (isWin) matchResult.winner = playerId;
+    else matchResult.loser = playerId;
+    // [2-2] gameOverNotification 패킷 만들어 전송
+    player.user.sendPacket(config.packetType.gameOverNotification, { isWin });
+    // [2-3] 전적 및 최고 기록 최신화
+    player.user.updateMatchRecord(isWin, player.score);
+  });
+  // [3] 각 유저 mmr 최신화
+  room.updateMmr(matchResult);
+  // [4] 룸 세션에서 매치 종료된 룸 제거
+  roomSession.deleteRoom(room.id);
+};
+
+export default finishMatch;

--- a/src/utils/match/start.match.js
+++ b/src/utils/match/start.match.js
@@ -1,15 +1,15 @@
 import config from '../../config/configs.js';
 import { userSession } from '../../session/session.js';
-import makePath from '../../utils/path/make.monster.path.js';
-import makePacketBuffer from '../../utils/send-packet/makePacket.js';
+import makePath from '../path/make.monster.path.js';
+import makePacketBuffer from '../send-packet/makePacket.js';
 import {
   makeBaseData,
   makeGameState,
   makeInitialGameState,
-} from '../../utils/send-packet/payload/game.data.js';
-import { makeMatchStartNotification } from '../../utils/send-packet/payload/notification/game.notification.js';
+} from '../send-packet/payload/game.data.js';
+import { makeMatchStartNotification } from '../send-packet/payload/notification/game.notification.js';
 
-const startMatchHandler = (room) => {
+const startMatch = (room) => {
   let monsterPath = {};
   let playerData = {};
   const playerId = [];
@@ -54,4 +54,4 @@ const startMatchHandler = (room) => {
   });
 };
 
-export default startMatchHandler;
+export default startMatch;


### PR DESCRIPTION
1. Room 클래스에 clearRoom 메서드 추가
- 소속 유저들의 roomId 초기화 및 clear() 실행
2. RoomSession 클래스의 deleteRoom 메서드 개편
- delete() 전에 해당 룸 clearRoom 실행
3. User 클래스의 updateMatchRecord 메서드 보완
- this.highScore 갱신 로직 추가
4. 게임 종료 시 유저 정보 데이터베이스에 update 하는 쿼리 및 그 쿼리 실행하는 함수 구현
5. utils 폴더에 match 폴더 신설
- 기존 start.match.handler.js 옮기고 start.match.js로 개명
- finish.match.js 추가
6. onEnd 함수 구현
- 게임 화면일 때와 로비 화면일 때의 종료 처리 분기 구분
- users 테이블에 update 쿼리 실행
- 소켓 제거